### PR TITLE
Fix android crash issue due to wrong refcount abort on A770/A750

### DIFF
--- a/shared/source/utilities/buffer_pool_allocator.h
+++ b/shared/source/utilities/buffer_pool_allocator.h
@@ -49,6 +49,7 @@ struct AbstractBuffersPool : public SmallBuffersParams<PoolT>, public NonCopyabl
     AbstractBuffersPool(MemoryManager *memoryManager, OnChunkFreeCallback onChunkFreeCallback);
     AbstractBuffersPool(AbstractBuffersPool<PoolT, BufferType, BufferParentType> &&bufferPool);
     AbstractBuffersPool &operator=(AbstractBuffersPool &&) = delete;
+    virtual ~AbstractBuffersPool();
     void tryFreeFromPoolBuffer(BufferParentType *possiblePoolBuffer, size_t offset, size_t size);
     bool isPoolBuffer(const BufferParentType *buffer) const;
     void drain();
@@ -61,6 +62,7 @@ struct AbstractBuffersPool : public SmallBuffersParams<PoolT>, public NonCopyabl
 
     MemoryManager *memoryManager{nullptr};
     std::unique_ptr<BufferType> mainStorage;
+    BufferType* tempStoragePointerCache{nullptr}; // clang: cache unqiue_ptr value for pool buffer judge logic in case pool buffer destruct itself
     std::unique_ptr<HeapAllocator> chunkAllocator;
     std::vector<std::pair<uint64_t, size_t>> chunksToFree;
     OnChunkFreeCallback onChunkFreeCallback = nullptr;

--- a/shared/source/utilities/buffer_pool_allocator.inl
+++ b/shared/source/utilities/buffer_pool_allocator.inl
@@ -34,10 +34,16 @@ void AbstractBuffersPool<PoolT, BufferType, BufferParentType>::tryFreeFromPoolBu
 }
 
 template <typename PoolT, typename BufferType, typename BufferParentType>
+AbstractBuffersPool<PoolT, BufferType, BufferParentType>::~AbstractBuffersPool()
+{
+    tempStoragePointerCache = mainStorage.get();
+}
+
+template <typename PoolT, typename BufferType, typename BufferParentType>
 bool AbstractBuffersPool<PoolT, BufferType, BufferParentType>::isPoolBuffer(const BufferParentType *buffer) const {
     static_assert(std::is_base_of_v<BufferParentType, BufferType>);
 
-    return (buffer && this->mainStorage.get() == buffer);
+    return (buffer && (this->mainStorage.get() == buffer || this->tempStoragePointerCache == buffer)); // for clang, unique_ptr is assigned nullptr firstly
 }
 
 template <typename PoolT, typename BufferType, typename BufferParentType>


### PR DESCRIPTION
The issue root-caused to different compilers' behavior of unique_ptr deletor clang set nullptr firstly and do destruction, but gcc is the opposite.

Tracked-On: OAM-122042