### PR TITLE
Modify default cache directory for opencl

### DIFF
--- a/shared/source/compiler_interface/linux/os_compiler_cache_helper.cpp
+++ b/shared/source/compiler_interface/linux/os_compiler_cache_helper.cpp
@@ -45,10 +45,38 @@ bool checkDefaultCacheDirSettings(std::string &cacheDir, NEO::EnvironmentVariabl
     cacheDir = reader.getSetting("XDG_CACHE_HOME", emptyString);
 
     if (cacheDir.empty()) {
+#ifdef ANDROID
+        cacheDir = "/data/data";
+        cacheDir = joinPath(cacheDir, getprogname());
+	if (!NEO::SysCalls::pathExists(cacheDir)) {
+                NEO::SysCalls::mkdir(cacheDir);
+        }
+
+	//in case mkdir fails use /data/local/tmp/cache/ as fallback cache dir
+	if (!NEO::SysCalls::pathExists(cacheDir)) {
+
+            PRINT_DEBUG_STRING(NEO::debugManager.flags.PrintDebugMessages.get(), stdout, "unable to create cache in:  %s\n\n",
+                           cacheDir.c_str());
+
+	    cacheDir = "/data/local/tmp/cache";
+	    if (!NEO::SysCalls::pathExists(cacheDir)) {
+                NEO::SysCalls::mkdir(cacheDir);
+            }
+
+	    cacheDir = joinPath(cacheDir, getprogname());
+	    if (!NEO::SysCalls::pathExists(cacheDir)) {
+                NEO::SysCalls::mkdir(cacheDir);
+            }
+
+            PRINT_DEBUG_STRING(NEO::debugManager.flags.PrintDebugMessages.get(), stdout, "Trying to create cache in:  %s\n\n",
+                           cacheDir.c_str());
+	}
+#else
         cacheDir = reader.getSetting("HOME", emptyString);
         if (cacheDir.empty()) {
             return false;
         }
+#endif
 
         // .cache might not exist on fresh installation
         cacheDir = joinPath(cacheDir, ".cache/");


### PR DESCRIPTION
Changes done:
- Add /data/data/progname/.cache/neo_compiler_cache as default Cache Dir for Android

Tests done:
- Android build
- Boot and verified with tflite gpu delegate with openCL

Tracked-On: OAM-126593