### PR TITLE
Fix opencl build error due to undefined char_traits

### DIFF
--- a/opencl/source/sharings/gl/linux/gl_sharing_linux.cpp
+++ b/opencl/source/sharings/gl/linux/gl_sharing_linux.cpp
@@ -20,7 +20,7 @@ GLSharingFunctionsLinux::GLSharingFunctionsLinux(GLType glhdcType, GLContext glh
 }
 GLSharingFunctionsLinux::~GLSharingFunctionsLinux() = default;
 
-bool GLSharingFunctionsLinux::isOpenGlExtensionSupported(const unsigned char *pExtensionString) {
+bool GLSharingFunctionsLinux::isOpenGlExtensionSupported(const char *pExtensionString) {
     if (glGetStringi == nullptr || glGetIntegerv == nullptr) {
         return false;
     }
@@ -28,7 +28,7 @@ bool GLSharingFunctionsLinux::isOpenGlExtensionSupported(const unsigned char *pE
     cl_int numberOfExtensions = 0;
     glGetIntegerv(GL_NUM_EXTENSIONS, &numberOfExtensions);
     for (cl_int i = 0; i < numberOfExtensions; i++) {
-        std::basic_string<unsigned char> pString = glGetStringi(GL_EXTENSIONS, i);
+        std::basic_string pString = reinterpret_cast<const char*> (glGetStringi(GL_EXTENSIONS, i));
         if (pString == pExtensionString) {
             return true;
         }
@@ -38,34 +38,34 @@ bool GLSharingFunctionsLinux::isOpenGlExtensionSupported(const unsigned char *pE
 
 bool GLSharingFunctionsLinux::isOpenGlSharingSupported() {
 
-    std::basic_string<unsigned char> vendor = glGetString(GL_VENDOR);
-    const unsigned char intelVendor[] = "Intel";
+    std::basic_string vendor = reinterpret_cast<const char*> (glGetString(GL_VENDOR));
+    const char intelVendor[] = "Intel";
 
     if ((vendor.empty()) || (vendor != intelVendor)) {
         return false;
     }
-    std::basic_string<unsigned char> version = glGetString(GL_VERSION);
+    std::basic_string version = reinterpret_cast<const char*> (glGetString(GL_VERSION));
     if (version.empty()) {
         return false;
     }
 
     bool isOpenGLES = false;
-    const unsigned char versionES[] = "OpenGL ES";
+    const char versionES[] = "OpenGL ES";
     if (version.find(versionES) != std::string::npos) {
         isOpenGLES = true;
     }
 
     if (isOpenGLES == true) {
-        const unsigned char versionES1[] = "OpenGL ES 1.";
+        const char versionES1[] = "OpenGL ES 1.";
         if (version.find(versionES1) != std::string::npos) {
-            const unsigned char supportGLOES[] = "GL_OES_framebuffer_object";
+            const char supportGLOES[] = "GL_OES_framebuffer_object";
             if (isOpenGlExtensionSupported(supportGLOES) == false) {
                 return false;
             }
         }
     } else {
         if (version[0] < '3') {
-            const unsigned char supportGLEXT[] = "GL_EXT_framebuffer_object";
+            const char supportGLEXT[] = "GL_EXT_framebuffer_object";
             if (isOpenGlExtensionSupported(supportGLEXT) == false) {
                 return false;
             }

--- a/opencl/source/sharings/gl/linux/gl_sharing_linux.h
+++ b/opencl/source/sharings/gl/linux/gl_sharing_linux.h
@@ -119,7 +119,7 @@ class GLSharingFunctionsLinux : public GLSharingFunctions {
     std::vector<std::pair<unsigned int, GraphicsAllocation *>> graphicsAllocationsForGlBufferReuse;
 
   protected:
-    bool isOpenGlExtensionSupported(const unsigned char *pExtentionString);
+    bool isOpenGlExtensionSupported(const char *pExtentionString);
 
     // Handles
     GLType glHDCType = 0;


### PR DESCRIPTION
With the latest update to clang 19.0.0, the compiler reports error when using std::basic_string<unsigned char>, because there is no template definition for std::char_traits<unsigned char>.

Changes done:
-Since we are using these strings to store text values, we can treat them as signed char, and use the basic string functionalities.

Tests done:
-Verify AiBenchmark and tflite_benchmark with GPU.

Tracked-On: OAM-129141